### PR TITLE
Added: New config options for set service name

### DIFF
--- a/cslb.go
+++ b/cslb.go
@@ -50,6 +50,8 @@ type config struct {
 	DisableHealthChecks  bool // "H"
 	AllowNumericServices bool // "N"
 
+	ServiceName string // Name of the service for SRV Lookup
+
 	StatusServerAddress   string // Listen address of status server
 	StatusServerTemplates string // filepath.Glob of replacement templates for status server
 
@@ -195,6 +197,7 @@ func newCslb() *cslb {
 
 	t.StatusServerAddress = os.Getenv(cslbEnvPrefix + "listen")
 	t.StatusServerTemplates = os.Getenv(cslbEnvPrefix + "templates")
+	t.ServiceName = os.Getenv(cslbEnvPrefix + "service_name")
 
 	t.HealthCheckFrequency = getAndParseDuration(cslbEnvPrefix+"hc_freq", t.HealthCheckFrequency)
 	t.InterceptTimeout = getAndParseDuration(cslbEnvPrefix+"timeout", t.InterceptTimeout)

--- a/dial.go
+++ b/dial.go
@@ -53,14 +53,18 @@ func (t *cslb) dialContext(ctx context.Context, network, address string) (net.Co
 	// passes scheme and port down to the Dial functions.
 
 	service := ""
-	switch port { // Map services that we can enable (which is only net/http for now)
-	case "80":
-		service = "http"
-	case "443":
-		service = "https"
-	default:
-		if t.AllowNumericServices { // Are we allowed to try _1443._tcp.$domain ?
-			service = port
+	if t.ServiceName != "" {
+		service = t.ServiceName
+	} else {
+		switch port { // Map services that we can enable (which is only net/http for now)
+		case "80":
+			service = "http"
+		case "443":
+			service = "https"
+		default:
+			if t.AllowNumericServices { // Are we allowed to try _1443._tcp.$domain ?
+				service = port
+			}
 		}
 	}
 


### PR DESCRIPTION
I want to use this library with my k8s service, but my port name is "service" and the port is 5000. And this library doesn't allow anything other than http or port number. I created a headless service to have an SRV record and k8s uses the port name as the service name ex: '_port-name._port-protocol.my-svc.my-namespace.svc.cluster-domain.example '.

k8s doc on SRV records : https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#srv-records

Thanks to this PR I can put 'cslb_service_name: "service"' in environment variable, it allows me to be compatible with the SRV records generated by k8s.

