### PR TITLE
Disable auto init altering default http transport

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/markdingo/cslb
+module github.com/rudderlabs/cslb
 
 go 1.21


### PR DESCRIPTION
* Stops auto enabling of Cslb for default http transport on package import.
* Adds new environment variable `cslb_auto_init_enabled` to use the previous behaviour of auto initialisation
* library users now need to explicitly call Setup and enable Cslb for any http transport.